### PR TITLE
Only build if Tarsnap is missing

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,58 +1,74 @@
 ---
+- name: Check if Tarsnap {{ tarsnap_version }} is installed
+  shell: tarsnap --version | grep {{ tarsnap_version }} --color=never
+  register: tarnsap_installed
+  changed_when: "tarnsap_installed.stderr != ''"
+  ignore_errors: yes
+
 - name: Install dependencies for Tarsnap
   apt: pkg={{item}} state=installed update_cache=yes cache_valid_time=3600
+  when: tarnsap_installed|failed
   with_items:
     - libssl-dev
     - zlib1g-dev
     - e2fslibs-dev
     - build-essential
-    
+
 - name: Download the current tarsnap code signing key
+  when: tarnsap_installed|failed
   get_url:
     url=https://www.tarsnap.com/tarsnap-signing-key.asc
     dest="{{base_dir}}/tarsnap-signing-key.asc"
 
 - name: Add the tarsnap code signing key to your list of keys
+  when: tarnsap_installed|failed
   command:
     gpg --import tarsnap-signing-key.asc
     chdir={{base_dir}}
-    
+
 - name: Download tarsnap SHA file
+  when: tarnsap_installed|failed
   get_url:
     url="https://www.tarsnap.com/download/tarsnap-sigs-{{tarsnap_version}}.asc"
     dest="{{base_dir}}/tarsnap-sigs-{{tarsnap_version}}.asc"
-    
+
 - name: Make the command that gets the current sha
+  when: tarnsap_installed|failed
   template:
     src=getSha.sh
     dest="{{base_dir}}/getSha.sh"
     mode=0755
-    
+
 - name: get the SHA256sum for this tarsnap release
+  when: tarnsap_installed|failed
   command:
     ./getSha.sh
     chdir={{base_dir}}
   register: tarsnap_sha
-  
+
 - name: Download Tarsnap source
+  when: tarnsap_installed|failed
   get_url:
     url="https://www.tarsnap.com/download/tarsnap-autoconf-{{tarsnap_version}}.tgz"
     dest="{{base_dir}}/tarsnap-autoconf-{{tarsnap_version}}.tgz"
     sha256sum={{tarsnap_sha.stdout_lines[0]}}
 
 - name: Decompress Tarsnap source
+  when: tarnsap_installed|failed
   command:
     tar xzf "{{base_dir}}/tarsnap-autoconf-{{tarsnap_version}}.tgz"
     chdir={{base_dir}}
     creates="{{base_dir}}/tarsnap-autoconf-{{tarsnap_version}}/COPYING"
 
 - name: Configure Tarsnap for local build
+  when: tarnsap_installed|failed
   command:
     ./configure
     chdir="{{base_dir}}/tarsnap-autoconf-{{tarsnap_version}}"
     creates="{{base_dir}}/tarsnap-autoconf-{{tarsnap_version}}/Makefile"
 
 - name: Build and install Tarsnap
+  when: tarnsap_installed|failed
   command:
     make all install clean
     chdir="{{base_dir}}/tarsnap-autoconf-{{tarsnap_version}}"


### PR DESCRIPTION
Checks if the specified version of Tarsnap is already installed before building anything.
